### PR TITLE
Activate extension on command kuskus.loadSymbols

### DIFF
--- a/kusto-language-server/client/src/extension.ts
+++ b/kusto-language-server/client/src/extension.ts
@@ -83,9 +83,9 @@ export function activate(context: ExtensionContext) {
           verificationUrl: string;
           verificationCode: string;
         }) => {
-          window.showInformationMessage(
-            `[kuskus.loadSymbols.auth] cluster ${clusterUri} database ${database} verificationUrl ${verificationUrl} verificationCode ${verificationCode}`,
-          );
+          // window.showInformationMessage(
+          //   `[kuskus.loadSymbols.auth] cluster ${clusterUri} database ${database} verificationUrl ${verificationUrl} verificationCode ${verificationCode}`,
+          // );
           let clipboardWriteSucceeded = false;
           try {
             clipboardy.writeSync(verificationCode);

--- a/kusto-language-server/package.json
+++ b/kusto-language-server/package.json
@@ -31,7 +31,8 @@
         "kql"
     ],
     "activationEvents": [
-        "onLanguage:kusto"
+        "onLanguage:kusto",
+        "onCommand:kuskus:loadSymbols"
     ],
     "main": "./client/out/extension",
     "contributes": {

--- a/kusto-language-server/package.json
+++ b/kusto-language-server/package.json
@@ -32,7 +32,7 @@
     ],
     "activationEvents": [
         "onLanguage:kusto",
-        "onCommand:kuskus:loadSymbols"
+        "onCommand:kuskus.loadSymbols"
     ],
     "main": "./client/out/extension",
     "contributes": {


### PR DESCRIPTION
Should fix #74 for older vs code versions according to https://stackoverflow.com/questions/49534068/command-not-found-in-vscode-extension