### PR TITLE
Fix .vscodeignore for client

### DIFF
--- a/kusto-language-server/.vscodeignore
+++ b/kusto-language-server/.vscodeignore
@@ -6,10 +6,6 @@
 **/tsconfig.base.json
 contributing.md
 .travis.yml
-client/node_modules/**
-!client/node_modules/vscode-jsonrpc/**
-!client/node_modules/vscode-languageclient/**
-!client/node_modules/vscode-languageserver-protocol/**
-!client/node_modules/vscode-languageserver-types/**
-!client/node_modules/semver/**
-!server/node_modules/vscode-languageserver/**
+client/src/test/**
+JANK_CLEANUP.md
+tslint.json


### PR DESCRIPTION
This was causing the extension to crash on activation. Caused indirectly by removing the dependencies from the root package.json in #146 