### PR TITLE
Add support for multiline strings

### DIFF
--- a/kusto-syntax-highlighting/README.md
+++ b/kusto-syntax-highlighting/README.md
@@ -8,9 +8,9 @@ The syntax is originally based on [TextmateBundleInstaller's Kusto syntax](https
 
 ![Kusto language syntax](https://github.com/rosshamish/kuskus/raw/master/kusto-syntax-highlighting/images/screenshot2.png)
 
-## Changelog
+## Contributing
 
-See CHANGELOG.md
+See CONTRIBUTING.md
 
 ## Bugs
 

--- a/kusto-syntax-highlighting/syntaxes/kusto.tmLanguage.json
+++ b/kusto-syntax-highlighting/syntaxes/kusto.tmLanguage.json
@@ -614,6 +614,27 @@
           ],
           "name": "string.quoted.single.kusto",
           "comment": "https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/string"
+        },
+        {
+          "begin": "([@h]?```)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.kusto"
+            }
+          },
+          "end": "```",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.kusto"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#Escapes"
+            }
+          ],
+          "name": "string.quoted.multi.kusto",
+          "comment": "https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/string#multi-line-string-literals"
         }
       ]
     },

--- a/kusto-syntax-highlighting/syntaxes/kusto.tmLanguage.yml
+++ b/kusto-syntax-highlighting/syntaxes/kusto.tmLanguage.yml
@@ -335,6 +335,18 @@ repository:
           - include: '#Escapes'
         name: string.quoted.single.kusto
         comment: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/string
+
+      - begin: "([@h]?```)"
+        beginCaptures:
+          '1': { name: punctuation.definition.string.kusto }
+        end: "```"
+        endCaptures:
+          '0': { name: punctuation.definition.string.kusto }
+        patterns:
+          - include: '#Escapes'
+        name: string.quoted.multi.kusto
+        comment: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/scalar-data-types/string#multi-line-string-literals
+
   Escapes:
     patterns:
       - match: (\\['"]|\\\\)

--- a/kusto-syntax-highlighting/test/snapshots/data-types/strings.kql.snap
+++ b/kusto-syntax-highlighting/test/snapshots/data-types/strings.kql.snap
@@ -115,21 +115,19 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto comment.line.kusto
 >print program=```
 #^^^^^ source.kusto keyword.other.query.kusto
-#     ^^^^^^^^^^^^^ source.kusto
+#     ^^^^^^^^^ source.kusto
+#              ^^^ source.kusto string.quoted.multi.kusto punctuation.definition.string.kusto
 >  public class Program {
-#^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto
+#^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto string.quoted.multi.kusto
 >    public static void Main() {
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto string.quoted.multi.kusto
 >      System.Console.WriteLine("Hello!");
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto
-#                               ^ source.kusto string.quoted.double.kusto punctuation.definition.string.kusto
-#                                ^^^^^^ source.kusto string.quoted.double.kusto
-#                                      ^ source.kusto string.quoted.double.kusto punctuation.definition.string.kusto
-#                                       ^^^ source.kusto
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto string.quoted.multi.kusto
 >    }
-#^^^^^^ source.kusto
+#^^^^^^ source.kusto string.quoted.multi.kusto
 >  }```
-#^^^^^^^ source.kusto
+#^^^ source.kusto string.quoted.multi.kusto
+#   ^^^ source.kusto string.quoted.multi.kusto punctuation.definition.string.kusto
 >
 >h'hello'
 #^^ source.kusto string.quoted.single.kusto punctuation.definition.string.kusto


### PR DESCRIPTION
Speculative fix for bug #166 following instructions in CONTRIBUTING.md

Updated snapshot for test/snapshots/data-types/strings.kql which already had a multi-line string present. Snapshot looks good by inspection. Also tested locally w/ launch config, looks good visually.