### PR TITLE
Work around Oniguruma bug in TM grammar regex

### DIFF
--- a/kusto-syntax-highlighting/syntaxes/kusto.tmLanguage.json
+++ b/kusto-syntax-highlighting/syntaxes/kusto.tmLanguage.json
@@ -226,7 +226,7 @@
       "comment": "User-defined functions: https://docs.microsoft.com/en-us/azure/kusto/query/functions/user-defined-functions"
     },
     {
-      "match": "(?<=let ).+(?=\\W*=)",
+      "match": "(?<=let )[^\\n]+(?=\\W*=)",
       "name": "entity.function.name.lambda.kusto",
       "comment": "User-defined functions: https://docs.microsoft.com/en-us/azure/kusto/query/functions/user-defined-functions"
     },

--- a/kusto-syntax-highlighting/syntaxes/kusto.tmLanguage.yml
+++ b/kusto-syntax-highlighting/syntaxes/kusto.tmLanguage.yml
@@ -121,7 +121,7 @@ patterns:
     name: keyword.control.kusto
     comment: 'User-defined functions: https://docs.microsoft.com/en-us/azure/kusto/query/functions/user-defined-functions'
 
-  - match: (?<=let ).+(?=\W*=)
+  - match: (?<=let )[^\n]+(?=\W*=)
     name: entity.function.name.lambda.kusto
     comment: 'User-defined functions: https://docs.microsoft.com/en-us/azure/kusto/query/functions/user-defined-functions'
 

--- a/kusto-syntax-highlighting/test/snapshots/create-or-alter-function/create-or-alter-function.csl.snap
+++ b/kusto-syntax-highlighting/test/snapshots/create-or-alter-function/create-or-alter-function.csl.snap
@@ -26,7 +26,9 @@
 >    let b = c;
 #^^^^ source.kusto
 #    ^^^ source.kusto keyword.control.kusto
-#       ^^^^^^^^ source.kusto
+#       ^ source.kusto
+#        ^^ source.kusto entity.function.name.lambda.kusto
+#          ^^^^^ source.kusto
 >    T
 #^^^^^^ source.kusto
 >    | where foo == 1234 and bar and baz !in beer

--- a/kusto-syntax-highlighting/test/snapshots/events/events.csl.snap
+++ b/kusto-syntax-highlighting/test/snapshots/events/events.csl.snap
@@ -1,8 +1,8 @@
 >let Events = MyLogTable | where A=B;
 #^^^ source.kusto keyword.control.kusto
-#   ^^^^^^^^^^^^^^^^^^^^^^^ source.kusto
-#                          ^^^^^ source.kusto keyword.other.query.kusto
-#                               ^^^^^^ source.kusto
+#   ^ source.kusto
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto entity.function.name.lambda.kusto
+#                                 ^^^^ source.kusto
 >
 >Events
 #^^^^^^^ source.kusto

--- a/kusto-syntax-highlighting/test/snapshots/regression-tests/escaped-backlash-in-string.kusto.snap
+++ b/kusto-syntax-highlighting/test/snapshots/regression-tests/escaped-backlash-in-string.kusto.snap
@@ -1,6 +1,8 @@
 >let scannerId = "9d632724-5c18-43e9-9314-555e9587b30c";
 #^^^ source.kusto keyword.control.kusto
-#   ^^^^^^^^^^^^^ source.kusto
+#   ^ source.kusto
+#    ^^^^^^^^^^ source.kusto entity.function.name.lambda.kusto
+#              ^^ source.kusto
 #                ^ source.kusto string.quoted.double.kusto punctuation.definition.string.kusto
 #                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto string.quoted.double.kusto
 #                                                     ^ source.kusto string.quoted.double.kusto punctuation.definition.string.kusto

--- a/kusto-syntax-highlighting/test/snapshots/scalar-functions/format_datetime.kql.snap
+++ b/kusto-syntax-highlighting/test/snapshots/scalar-functions/format_datetime.kql.snap
@@ -32,7 +32,9 @@
 >
 >let dt = datetime(2017-01-29 09:00:05);
 #^^^ source.kusto keyword.control.kusto
-#   ^^^^^^ source.kusto
+#   ^ source.kusto
+#    ^^^ source.kusto entity.function.name.lambda.kusto
+#       ^^ source.kusto
 #         ^^^^^^^^ source.kusto storage.type.kusto
 #                 ^ source.kusto
 #                  ^^^^ source.kusto constant.numeric.kusto

--- a/kusto-syntax-highlighting/test/snapshots/tabular-operators/invoke.kql.snap
+++ b/kusto-syntax-highlighting/test/snapshots/tabular-operators/invoke.kql.snap
@@ -7,7 +7,9 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto comment.line.kusto
 >let clipped_average = (T:(x: long), lowPercentile:double, upPercentile:double)
 #^^^ source.kusto keyword.control.kusto
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto
+#   ^ source.kusto
+#    ^^^^^^^^^^^^^^^^ source.kusto entity.function.name.lambda.kusto
+#                    ^^^^^^^^^ source.kusto
 #                             ^^^^ source.kusto storage.type.kusto
 #                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.kusto
 >{
@@ -15,7 +17,9 @@
 >   let high = toscalar(T | summarize percentiles(x, upPercentile));
 #^^^ source.kusto
 #   ^^^ source.kusto keyword.control.kusto
-#      ^^^^^^^^ source.kusto
+#      ^ source.kusto
+#       ^^^^^ source.kusto entity.function.name.lambda.kusto
+#            ^^ source.kusto
 #              ^^^^^^^^ source.kusto support.function.kusto
 #                      ^^^^^ source.kusto
 #                           ^^^^^^^^^ source.kusto keyword.other.query.kusto
@@ -25,7 +29,9 @@
 >   let low = toscalar(T | summarize percentiles(x, lowPercentile));
 #^^^ source.kusto
 #   ^^^ source.kusto keyword.control.kusto
-#      ^^^^^^^ source.kusto
+#      ^ source.kusto
+#       ^^^^ source.kusto entity.function.name.lambda.kusto
+#           ^^ source.kusto
 #             ^^^^^^^^ source.kusto support.function.kusto
 #                     ^^^^^ source.kusto
 #                          ^^^^^^^^^ source.kusto keyword.other.query.kusto

--- a/kusto-syntax-highlighting/test/snapshots/tabular-operators/sample.kql.snap
+++ b/kusto-syntax-highlighting/test/snapshots/tabular-operators/sample.kql.snap
@@ -3,7 +3,9 @@
 >
 >let _data = range x from 1 to 100 step 1;
 #^^^ source.kusto keyword.control.kusto
-#   ^^^^^^^^^ source.kusto
+#   ^ source.kusto
+#    ^^^^^^ source.kusto entity.function.name.lambda.kusto
+#          ^^ source.kusto
 #            ^^^^^ source.kusto meta.query.range.kusto keyword.other.query.kusto
 #                 ^ source.kusto meta.query.range.kusto
 #                  ^ source.kusto meta.query.range.kusto variable.other.column.kusto
@@ -22,7 +24,9 @@
 #                                        ^^ source.kusto
 >let _sample = _data | sample 1;
 #^^^ source.kusto keyword.control.kusto
-#   ^^^^^^^^^^^^^^^^^^^ source.kusto
+#   ^ source.kusto
+#    ^^^^^^^^ source.kusto entity.function.name.lambda.kusto
+#            ^^^^^^^^^^ source.kusto
 #                      ^^^^^^ source.kusto meta.query.sample.kusto keyword.other.query.kusto
 #                            ^ source.kusto meta.query.sample.kusto
 #                             ^ source.kusto meta.query.sample.kusto constant.numeric.kusto


### PR DESCRIPTION
Fixes #209. A bug in Oniguruma was preventing this regex from ever matching (more details in the linked issue). This change works around the bug by simply changing `.` to `[^\n]` (which is identically equivalent in Oniguruma, where `\n` is the only newline char).