### PR TITLE
docs: add supply chain + contributor experience reports (2026-03-04)

### DIFF
--- a/docs/2026-03-04-contributor-experience.md
+++ b/docs/2026-03-04-contributor-experience.md
@@ -1,0 +1,29 @@
+# Contributor Experience Improvements — 2026-03-04
+
+## Bug reports / feature requests
+- Added ISSUE_TEMPLATE for bugs and features — structured forms instead of blank issues ([52e4dd6](https://github.com/rosshamish/kuskus/commit/52e4dd61))
+- Closed 8+ stale issues (some 5+ years old) with kind messages pointing to CONTRIBUTING.md — signal/noise ratio improved
+- Added "Contributions Welcome" table to README with 4 community-requested ideas + issue links — new contributors land somewhere actionable
+
+## Opening a PR
+- PR template added with Why/What/How structure ([1366ddd](https://github.com/rosshamish/kuskus/commit/1366ddd5))
+- Version bump CI check — if you forget to bump, CI tells you exactly which package and exactly what command to run ([5067b41](https://github.com/rosshamish/kuskus/commit/5067b41a), [edba9b3](https://github.com/rosshamish/kuskus/commit/edba9b3d))
+
+## CONTRIBUTING.md — restructured (#289)
+Flows from new contributor → maintainer (prerequisites first, security policy last):
+1. Extensions in this repo
+2. Getting started (prerequisites, clone, build, run tests)
+3. Contribution flavors table with real example commits:
+   - Grammar / syntax fix — [2a5d25a](https://github.com/rosshamish/kuskus/commit/2a5d25aa)
+   - Language server feature — [841c908](https://github.com/rosshamish/kuskus/commit/841c9087)
+   - Color theme (new or modify) — [7aa46fd](https://github.com/rosshamish/kuskus/commit/7aa46fd4)
+   - New extension in the pack
+4. Making a change (branch naming, version bump)
+5. Opening a PR (CI checks)
+6. Never do these things
+7. Manual testing checklist (3 items genuinely can't be automated)
+8. Maintainer ops (PAT renewal)
+9. GitHub Actions security policy
+
+## Net experience change
+A new contributor can clone, build, pick a flavor, open a PR, and get useful CI feedback — without reading anything except CONTRIBUTING.md top to bottom. That wasn't true before.

--- a/docs/2026-03-04-supply-chain-security.md
+++ b/docs/2026-03-04-supply-chain-security.md
@@ -1,0 +1,25 @@
+# Supply Chain Security Hardening — 2026-03-04
+
+## What was hardened
+
+### 1. Dependency vulnerabilities patched
+- `axios` CVE, `minimatch` ReDoS, `serialize-javascript` CVE across all language-server packages ([8ba9492](https://github.com/rosshamish/kuskus/commit/8ba9492c)) — #272
+- `minimatch` ReDoS in `kusto-syntax-highlighting` specifically ([0af8308](https://github.com/rosshamish/kuskus/commit/0af8308d)) — shipped as v2.0.8
+
+### 2. GitHub Actions locked down ([ff774d3](https://github.com/rosshamish/kuskus/commit/ff774d38)) — #282
+- Default workflow permissions: `write` → **`read` only**
+- All actions SHA-pinned to full commit hash (no floating `@v1` tags — those can be silently replaced)
+- Explicit allowlist of permitted actions — no wildcards
+- `can_approve_pull_request_reviews` disabled for GITHUB_TOKEN
+
+### 3. Vendored/untrusted actions removed ([e5e50c5](https://github.com/rosshamish/kuskus/commit/e5e50c55)) — #265
+- Deleted `gh-action-bump-version-master/` and `jq-action-master/` from the repo — vendored third-party action copies with no integrity guarantee
+
+### 4. Post-publish auto-push removed ([fb0004b](https://github.com/rosshamish/kuskus/commit/fb0004ba)) — #284
+- Publish workflows were writing directly back to `master` (bypassing branch protection via CI token). Removed entirely — `contents: write` → `contents: read` on all publish workflows
+
+### 5. VSCE_PAT scope documented ([a693bcb](https://github.com/rosshamish/kuskus/commit/a693bcb2))
+- PAT renewal runbook added so the secret can be rotated correctly and with minimum scope
+
+## Net posture change
+Repo went from floating action tags + vendored copies + write-capable CI tokens + unpatched CVEs → SHA-pinned allowlist + read-only CI + no vendored code + clean deps. The publish pipeline is now the only thing with elevated access, and it's scoped to Marketplace only.


### PR DESCRIPTION
Persistent records of what was hardened and what was improved for contributors in this session.